### PR TITLE
CI fixes for PRs and other branches

### DIFF
--- a/.azure-pipelines/debug-arm.yml
+++ b/.azure-pipelines/debug-arm.yml
@@ -47,13 +47,13 @@ steps:
     platform: '$(BuildPlatform)'
     configuration: '$(BuildConfiguration)'
 
-# Does not discover any tests:
-- task: VSTest@2
-  inputs:
-    testSelector: 'testAssemblies'
-    testAssemblyVer2: '**\*_$(BuildPlatform)_$(BuildConfiguration).appxbundle'
-    searchFolder: '$(AppxPackageDir)'
-    otherConsoleOptions: '/Logger:trx'
+# Connecting to the test app fails with a timeout:
+#- task: VSTest@2
+#  inputs:
+#    testSelector: 'testAssemblies'
+#    testAssemblyVer2: '**\*_$(BuildPlatform)_$(BuildConfiguration).appxbundle'
+#    searchFolder: '$(AppxPackageDir)'
+#    otherConsoleOptions: '/Logger:trx'
 
 - task: PublishBuildArtifacts@1
   displayName: 'Publish Artifact'

--- a/.azure-pipelines/debug-arm.yml
+++ b/.azure-pipelines/debug-arm.yml
@@ -49,9 +49,6 @@ steps:
                   /p:AppxBundle=Always
                   /p:UapAppxPackageBuildMode=StoreUpload
                   /p:AppxPackageSigningEnabled=true
-                  /p:PackageCertificateThumbprint="7BB283898930C7D4322471492FD0710312287139" 
-                  /p:PackageCertificateKeyFile="$(signingCert.secureFilePath)"
-                  /p:PackageCertificatePassword="$(signingCert.password)"
                   /t:UWPX_UI'
     platform: '$(BuildPlatform)'
     configuration: '$(BuildConfiguration)'

--- a/.azure-pipelines/debug-arm.yml
+++ b/.azure-pipelines/debug-arm.yml
@@ -33,12 +33,6 @@ steps:
   inputs:
     restoreSolution: '$(Solution)'
 
-- task: DownloadSecureFile@1
-  name: 'signingCert'
-  displayName: 'Download Signing Certificate'
-  inputs:
-    secureFile: 'UWPX_TemporaryKey.pfx'
-
 - task: VSBuild@1
   displayName: 'Build $(BuildPlatform) Debug'
   inputs:

--- a/.azure-pipelines/debug-arm.yml
+++ b/.azure-pipelines/debug-arm.yml
@@ -53,23 +53,6 @@ steps:
     platform: '$(BuildPlatform)'
     configuration: '$(BuildConfiguration)'
 
-- task: PowerShell@2
-  displayName: 'Install PFX file'
-  inputs:
-    targetType: 'inline'
-    script: |
-      Write-Host "Start adding the PFX file to the certificate store."
-
-      $pfxpath = '$(signingCert.secureFilePath)'
-      
-      Add-Type -AssemblyName System.Security
-      $cert = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2
-      $cert.Import($pfxpath, "$(signingCert.password)", [System.Security.Cryptography.X509Certificates.X509KeyStorageFlags]"PersistKeySet")
-      $store = new-object system.security.cryptography.X509Certificates.X509Store -argumentlist "MY", CurrentUser
-      $store.Open([System.Security.Cryptography.X509Certificates.OpenFlags]"ReadWrite")
-      $store.Add($cert)
-      $store.Close()
-
 # Does not discover any tests:
 - task: VSTest@2
   inputs:

--- a/.azure-pipelines/debug-arm.yml
+++ b/.azure-pipelines/debug-arm.yml
@@ -47,8 +47,8 @@ steps:
     msbuildArgs: '/p:AppxBundlePlatforms="$(BuildPlatform)"
                   /p:AppxPackageDir="$(AppxPackageDir)"
                   /p:AppxBundle=Always
-                  /p:UapAppxPackageBuildMode=StoreUpload
-                  /p:AppxPackageSigningEnabled=true
+                  /p:UapAppxPackageBuildMode=CI
+                  /p:AppxPackageSigningEnabled=false
                   /t:UWPX_UI'
     platform: '$(BuildPlatform)'
     configuration: '$(BuildConfiguration)'

--- a/.azure-pipelines/debug-x64.yml
+++ b/.azure-pipelines/debug-x64.yml
@@ -54,15 +54,30 @@ steps:
     configuration: '$(BuildConfiguration)'
 
 # Does not discover any tests:
+- task: VisualStudioTestPlatformInstaller@1
+  inputs:
+    packageFeedSelector: 'nugetOrg'
+    versionSelector: 'latestPreRelease'
 - task: VSTest@2
   inputs:
     testSelector: 'testAssemblies'
-    testAssemblyVer2: '**\*_$(BuildPlatform)_$(BuildConfiguration).appxbundle'
+    testAssemblyVer2: |
+      **\*.build.appxrecipe
+      !**\obj\** 
     searchFolder: '$(AppxPackageDir)'
+    resultsFolder: '$(System.DefaultWorkingDirectory)\TestResults'
     otherConsoleOptions: '/Logger:trx'
+    platform: '$(BuildPlatform)'
+    configuration: '$(BuildConfiguration)'
+    runInParallel: false
+    codeCoverageEnabled: true
+    rerunFailedTests: false
+    runTestsInIsolation: true
+    runOnlyImpactedTests: false
 
-- task: PublishBuildArtifacts@1
-  displayName: 'Publish Artifact'
+- task: PublishTestResults@2
   inputs:
-    PathtoPublish: '$(Build.ArtifactStagingDirectory)'
-    ArtifactName: '$(ArtifactName)'
+    testResultsFormat: 'JUnit'
+    testResultsFiles: '**/TEST-*.xml'
+    searchFolder: '$(System.DefaultWorkingDirectory)\TestResults'
+    failTaskOnFailedTests: true

--- a/.azure-pipelines/debug-x64.yml
+++ b/.azure-pipelines/debug-x64.yml
@@ -49,9 +49,6 @@ steps:
                   /p:AppxBundle=Always
                   /p:UapAppxPackageBuildMode=StoreUpload
                   /p:AppxPackageSigningEnabled=true
-                  /p:PackageCertificateThumbprint="7BB283898930C7D4322471492FD0710312287139" 
-                  /p:PackageCertificateKeyFile="$(signingCert.secureFilePath)"
-                  /p:PackageCertificatePassword="$(signingCert.password)"
                   /t:UWPX_UI'
     platform: '$(BuildPlatform)'
     configuration: '$(BuildConfiguration)'

--- a/.azure-pipelines/debug-x64.yml
+++ b/.azure-pipelines/debug-x64.yml
@@ -33,12 +33,6 @@ steps:
   inputs:
     restoreSolution: '$(Solution)'
 
-- task: DownloadSecureFile@1
-  name: 'signingCert'
-  displayName: 'Download Signing Certificate'
-  inputs:
-    secureFile: 'UWPX_TemporaryKey.pfx'
-
 - task: VSBuild@1
   displayName: 'Build $(BuildPlatform) Debug'
   inputs:

--- a/.azure-pipelines/debug-x64.yml
+++ b/.azure-pipelines/debug-x64.yml
@@ -20,7 +20,7 @@ pool:
 variables:
   Solution: 'UWPX-Client.sln'
   BuildConfiguration: 'Debug'
-  BuildPlatform: 'x86'
+  BuildPlatform: 'x64'
   AppxPackageDir: '$(Build.artifactStagingDirectory)\AppxPackages\\'
   ArtifactName: 'UWPX-$(BuildPlatform)-$(BuildConfiguration)'
   System.Debug: true
@@ -48,31 +48,16 @@ steps:
     platform: '$(BuildPlatform)'
     configuration: '$(BuildConfiguration)'
 
-# Does not discover any tests:
-- task: VisualStudioTestPlatformInstaller@1
-  inputs:
-    packageFeedSelector: 'nugetOrg'
-    versionSelector: 'latestPreRelease'
-- task: VSTest@2
-  inputs:
-    testSelector: 'testAssemblies'
-    testAssemblyVer2: |
-      **\*.build.appxrecipe
-      !**\obj\** 
-    searchFolder: '$(Build.SourcesDirectory)'
-    resultsFolder: '$(System.DefaultWorkingDirectory)\TestResults'
-    otherConsoleOptions: '/Logger:trx'
-    platform: '$(BuildPlatform)'
-    configuration: '$(BuildConfiguration)'
-    runInParallel: false
-    codeCoverageEnabled: true
-    rerunFailedTests: false
-    runTestsInIsolation: true
-    runOnlyImpactedTests: false
+# Connecting to the test app fails with a timeout:
+#- task: VSTest@2
+#  inputs:
+#    testSelector: 'testAssemblies'
+#    testAssemblyVer2: '**\*_$(BuildPlatform)_$(BuildConfiguration).appxbundle'
+#    searchFolder: '$(AppxPackageDir)'
+#    otherConsoleOptions: '/Logger:trx'
 
-- task: PublishTestResults@2
+- task: PublishBuildArtifacts@1
+  displayName: 'Publish Artifact'
   inputs:
-    testResultsFormat: 'JUnit'
-    testResultsFiles: '**/TEST-*.xml'
-    searchFolder: '$(System.DefaultWorkingDirectory)\TestResults'
-    failTaskOnFailedTests: true
+    PathtoPublish: '$(Build.ArtifactStagingDirectory)'
+    ArtifactName: '$(ArtifactName)'

--- a/.azure-pipelines/debug-x64.yml
+++ b/.azure-pipelines/debug-x64.yml
@@ -23,6 +23,7 @@ variables:
   BuildPlatform: 'x86'
   AppxPackageDir: '$(Build.artifactStagingDirectory)\AppxPackages\\'
   ArtifactName: 'UWPX-$(BuildPlatform)-$(BuildConfiguration)'
+  VSTEST_CONNECTION_TIMEOUT: '600'
 
 steps:
 - task: NuGetToolInstaller@1

--- a/.azure-pipelines/debug-x64.yml
+++ b/.azure-pipelines/debug-x64.yml
@@ -53,23 +53,6 @@ steps:
     platform: '$(BuildPlatform)'
     configuration: '$(BuildConfiguration)'
 
-- task: PowerShell@2
-  displayName: 'Install PFX file'
-  inputs:
-    targetType: 'inline'
-    script: |
-      Write-Host "Start adding the PFX file to the certificate store."
-
-      $pfxpath = '$(signingCert.secureFilePath)'
-      
-      Add-Type -AssemblyName System.Security
-      $cert = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2
-      $cert.Import($pfxpath, "$(signingCert.password)", [System.Security.Cryptography.X509Certificates.X509KeyStorageFlags]"PersistKeySet")
-      $store = new-object system.security.cryptography.X509Certificates.X509Store -argumentlist "MY", CurrentUser
-      $store.Open([System.Security.Cryptography.X509Certificates.OpenFlags]"ReadWrite")
-      $store.Add($cert)
-      $store.Close()
-
 # Does not discover any tests:
 - task: VSTest@2
   inputs:

--- a/.azure-pipelines/debug-x64.yml
+++ b/.azure-pipelines/debug-x64.yml
@@ -23,7 +23,7 @@ variables:
   BuildPlatform: 'x86'
   AppxPackageDir: '$(Build.artifactStagingDirectory)\AppxPackages\\'
   ArtifactName: 'UWPX-$(BuildPlatform)-$(BuildConfiguration)'
-  VSTEST_CONNECTION_TIMEOUT: '600'
+  System.Debug: true
 
 steps:
 - task: NuGetToolInstaller@1

--- a/.azure-pipelines/debug-x64.yml
+++ b/.azure-pipelines/debug-x64.yml
@@ -47,8 +47,8 @@ steps:
     msbuildArgs: '/p:AppxBundlePlatforms="$(BuildPlatform)"
                   /p:AppxPackageDir="$(AppxPackageDir)"
                   /p:AppxBundle=Always
-                  /p:UapAppxPackageBuildMode=StoreUpload
-                  /p:AppxPackageSigningEnabled=true
+                  /p:UapAppxPackageBuildMode=CI
+                  /p:AppxPackageSigningEnabled=false
                   /t:UWPX_UI'
     platform: '$(BuildPlatform)'
     configuration: '$(BuildConfiguration)'

--- a/.azure-pipelines/debug-x64.yml
+++ b/.azure-pipelines/debug-x64.yml
@@ -58,7 +58,7 @@ steps:
     testAssemblyVer2: |
       **\*.build.appxrecipe
       !**\obj\** 
-    searchFolder: '$(AppxPackageDir)'
+    searchFolder: '$(Build.SourcesDirectory)'
     resultsFolder: '$(System.DefaultWorkingDirectory)\TestResults'
     otherConsoleOptions: '/Logger:trx'
     platform: '$(BuildPlatform)'

--- a/.azure-pipelines/debug-x86.yml
+++ b/.azure-pipelines/debug-x86.yml
@@ -47,13 +47,13 @@ steps:
     platform: '$(BuildPlatform)'
     configuration: '$(BuildConfiguration)'
 
-# Does not discover any tests:
-- task: VSTest@2
-  inputs:
-    testSelector: 'testAssemblies'
-    testAssemblyVer2: '**\*_$(BuildPlatform)_$(BuildConfiguration).appxbundle'
-    searchFolder: '$(AppxPackageDir)'
-    otherConsoleOptions: '/Logger:trx'
+# Connecting to the test app fails with a timeout:
+#- task: VSTest@2
+#  inputs:
+#    testSelector: 'testAssemblies'
+#    testAssemblyVer2: '**\*_$(BuildPlatform)_$(BuildConfiguration).appxbundle'
+#    searchFolder: '$(AppxPackageDir)'
+#    otherConsoleOptions: '/Logger:trx'
 
 - task: PublishBuildArtifacts@1
   displayName: 'Publish Artifact'

--- a/.azure-pipelines/debug-x86.yml
+++ b/.azure-pipelines/debug-x86.yml
@@ -47,23 +47,6 @@ steps:
     platform: '$(BuildPlatform)'
     configuration: '$(BuildConfiguration)'
 
-- task: PowerShell@2
-  displayName: 'Install PFX file'
-  inputs:
-    targetType: 'inline'
-    script: |
-      Write-Host "Start adding the PFX file to the certificate store."
-
-      $pfxpath = '$(signingCert.secureFilePath)'
-      
-      Add-Type -AssemblyName System.Security
-      $cert = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2
-      $cert.Import($pfxpath, "$(signingCert.password)", [System.Security.Cryptography.X509Certificates.X509KeyStorageFlags]"PersistKeySet")
-      $store = new-object system.security.cryptography.X509Certificates.X509Store -argumentlist "MY", CurrentUser
-      $store.Open([System.Security.Cryptography.X509Certificates.OpenFlags]"ReadWrite")
-      $store.Add($cert)
-      $store.Close()
-
 # Does not discover any tests:
 - task: VSTest@2
   inputs:

--- a/.azure-pipelines/debug-x86.yml
+++ b/.azure-pipelines/debug-x86.yml
@@ -41,8 +41,8 @@ steps:
     msbuildArgs: '/p:AppxBundlePlatforms="$(BuildPlatform)"
                   /p:AppxPackageDir="$(AppxPackageDir)"
                   /p:AppxBundle=Always
-                  /p:UapAppxPackageBuildMode=StoreUpload
-                  /p:AppxPackageSigningEnabled=true
+                  /p:UapAppxPackageBuildMode=CI
+                  /p:AppxPackageSigningEnabled=false
                   /t:UWPX_UI'
     platform: '$(BuildPlatform)'
     configuration: '$(BuildConfiguration)'

--- a/.azure-pipelines/debug-x86.yml
+++ b/.azure-pipelines/debug-x86.yml
@@ -33,12 +33,6 @@ steps:
   inputs:
     restoreSolution: '$(Solution)'
 
-- task: DownloadSecureFile@1
-  name: 'signingCert'
-  displayName: 'Download Signing Certificate'
-  inputs:
-    secureFile: 'UWPX_TemporaryKey.pfx'
-
 - task: VSBuild@1
   displayName: 'Build $(BuildPlatform) Debug'
   inputs:
@@ -49,9 +43,6 @@ steps:
                   /p:AppxBundle=Always
                   /p:UapAppxPackageBuildMode=StoreUpload
                   /p:AppxPackageSigningEnabled=true
-                  /p:PackageCertificateThumbprint="7BB283898930C7D4322471492FD0710312287139" 
-                  /p:PackageCertificateKeyFile="$(signingCert.secureFilePath)"
-                  /p:PackageCertificatePassword="$(signingCert.password)"
                   /t:UWPX_UI'
     platform: '$(BuildPlatform)'
     configuration: '$(BuildConfiguration)'

--- a/.azure-pipelines/release-sideload.yml
+++ b/.azure-pipelines/release-sideload.yml
@@ -3,8 +3,11 @@
 # Add steps that test and distribute an app, save build artifacts, and more:
 # https://aka.ms/yaml
 
-# Disable all commit triggers:
-trigger: none
+# Only run for master:
+trigger:
+  branches:
+    include:
+      - master
 
 # Disable PR triggers:
 pr: none


### PR DESCRIPTION
Currently the CI fails when building PRs due to the missing signing cert.
This PR aims to fix this.